### PR TITLE
Fix some incompatible pointer types errors

### DIFF
--- a/dvb-frontends/mxl58x.c
+++ b/dvb-frontends/mxl58x.c
@@ -327,7 +327,7 @@ static void release(struct dvb_frontend *fe)
 	kfree(state);
 }
 
-static int get_algo(struct dvb_frontend *fe)
+static enum dvbfe_algo get_algo(struct dvb_frontend *fe)
 {
 	return DVBFE_ALGO_HW;
 }

--- a/dvb-frontends/si2183.c
+++ b/dvb-frontends/si2183.c
@@ -1217,7 +1217,7 @@ static int si2183_tune(struct dvb_frontend *fe, bool re_tune,
 	return si2183_read_status(fe, status);
 }
 
-static int si2183_get_algo(struct dvb_frontend *fe)
+static enum dvbfe_algo si2183_get_algo(struct dvb_frontend *fe)
 {
 	return DVBFE_ALGO_HW;
 }

--- a/dvb-frontends/stid135/stid135-fe.c
+++ b/dvb-frontends/stid135/stid135-fe.c
@@ -619,7 +619,7 @@ static int stid135_tune(struct dvb_frontend *fe, bool re_tune,
 }
 
 
-static int stid135_get_algo(struct dvb_frontend *fe)
+static enum dvbfe_algo stid135_get_algo(struct dvb_frontend *fe)
 {
 	return DVBFE_ALGO_HW;
 }

--- a/dvb-frontends/stv091x.c
+++ b/dvb-frontends/stv091x.c
@@ -1462,7 +1462,7 @@ static int tune(struct dvb_frontend *fe, bool re_tune,
 }
 
 
-static int get_algo(struct dvb_frontend *fe)
+static enum dvbfe_algo get_algo(struct dvb_frontend *fe)
 {
 	return DVBFE_ALGO_HW;
 }

--- a/dvb-frontends/tas2101.c
+++ b/dvb-frontends/tas2101.c
@@ -848,7 +848,7 @@ static int tas2101_tune(struct dvb_frontend *fe, bool re_tune,
 	return tas2101_read_status(fe, status);
 }
 
-static int tas2101_get_algo(struct dvb_frontend *fe)
+static enum dvbfe_algo tas2101_get_algo(struct dvb_frontend *fe)
 {
 	return DVBFE_ALGO_HW;
 }

--- a/dvb-frontends/tas2971.c
+++ b/dvb-frontends/tas2971.c
@@ -405,7 +405,7 @@ return tas2101_read_status(fe, status);//lucy
 	
 }
 
-static int tas2101_get_algo(struct dvb_frontend *fe)
+static enum dvbfe_algo tas2101_get_algo(struct dvb_frontend *fe)
 {
 	return DVBFE_ALGO_HW;
 }


### PR DESCRIPTION
dkms compile failed, because of some "incompatible-pointer-types" warnings treated as errors. So I change the return type of some functions to the correct "enum dvbfe_algo" type.